### PR TITLE
Add base and bonus stat serialization to NPC stats

### DIFF
--- a/src/characters/npcs/NPCState.gd
+++ b/src/characters/npcs/NPCState.gd
@@ -62,24 +62,21 @@ func spend_sta(cost: float) -> bool:
 
 # ---------- Save/Load ----------
 func to_dict() -> Dictionary:
-	return {
-		"npc_id": npc_id,
-		"stats": stats.get_all_stats(), # nhẹ, đủ cho phần lớn trường hợp
-		"favorite_gifts": favorite_gifts.duplicate(),
-		"given_gifts": given_gifts.duplicate()
-	}
+        return {
+                "npc_id": npc_id,
+                "stats": stats.to_dict(),
+                "favorite_gifts": favorite_gifts.duplicate(),
+                "given_gifts": given_gifts.duplicate()
+        }
 
 func from_dict(d: Dictionary) -> void:
-	npc_id = d.get("npc_id", npc_id)
-	if d.has("stats"):
-		# nạp mềm các key có trong stats
-		for k in d["stats"].keys():
-			if stats.has_stat(k):
-				stats.set_stat_value(k, d["stats"][k])
-	favorite_gifts = d.get("favorite_gifts", favorite_gifts)
-	given_gifts = d.get("given_gifts", given_gifts)
-	# đảm bảo signal đã nối
-	setup_signals_once()
+        npc_id = d.get("npc_id", npc_id)
+        if d.has("stats"):
+                stats.from_dict(d["stats"])
+        favorite_gifts = d.get("favorite_gifts", favorite_gifts)
+        given_gifts = d.get("given_gifts", given_gifts)
+        # đảm bảo signal đã nối
+        setup_signals_once()
 
 # ---------- Re-emit nội bộ ----------
 func _on_stats_changed() -> void:

--- a/src/characters/npcs/NPCStats.gd
+++ b/src/characters/npcs/NPCStats.gd
@@ -69,11 +69,39 @@ func set_stat_value(key: String, value: float) -> void:
         _:
             super.set_stat_value(key, value)
 
-func get_all_stats() -> Dictionary:
-    var d = super.get_all_stats()
+func to_dict() -> Dictionary:
+    var d := super.to_dict()
     d.merge({
         "love": love, "max_love": max_love,
         "trust": trust, "max_trust": max_trust,
         "lust": lust, "max_lust": max_lust,
+    })
+    return d
+
+func from_dict(data: Dictionary) -> void:
+    super.from_dict(data)
+    love = data.get("love", love)
+    max_love = data.get("max_love", max_love)
+    trust = data.get("trust", trust)
+    max_trust = data.get("max_trust", max_trust)
+    lust = data.get("lust", lust)
+    max_lust = data.get("max_lust", max_lust)
+
+func get_all_stats() -> Dictionary:
+    var d = super.get_all_stats()
+    # Include social stats for convenience
+    d.merge({
+        "love": love, "max_love": max_love,
+        "trust": trust, "max_trust": max_trust,
+        "lust": lust, "max_lust": max_lust,
+        # Base and bonus attributes for serialization consumers
+        "base_strength": base_strength,
+        "base_dexterity": base_dexterity,
+        "base_intelligence": base_intelligence,
+        "base_agility": base_agility,
+        "bonus_strength": bonus_strength,
+        "bonus_dexterity": bonus_dexterity,
+        "bonus_intelligence": bonus_intelligence,
+        "bonus_agility": bonus_agility,
     })
     return d


### PR DESCRIPTION
## Summary
- Add to_dict/from_dict for NPCStats to serialize base and bonus attributes alongside social stats
- Expand NPCStats.get_all_stats to expose base_* and bonus_* for consumers
- Update NPCState serialization to use new stat methods

## Testing
- ⚠️ `godot --headless --check project.godot` *(Godot not installed)*
- ⚠️ `apt-get install -y godot4` *(package unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c9ae9eec8331a862bafff7eac3ca